### PR TITLE
Add SwiftUI wrapper for DashPlayerView

### DIFF
--- a/mpd/DashPlayerViewWrapper.swift
+++ b/mpd/DashPlayerViewWrapper.swift
@@ -1,0 +1,13 @@
+import SwiftUI
+
+struct DashPlayerViewWrapper: UIViewRepresentable {
+    let sampleBufferPlayer: DashSampleBufferPlayer
+
+    func makeUIView(context: Context) -> DashPlayerView {
+        DashPlayerView(player: sampleBufferPlayer)
+    }
+
+    func updateUIView(_ uiView: DashPlayerView, context: Context) {
+        // No updates needed for now
+    }
+}


### PR DESCRIPTION
## Summary
- Add `DashPlayerViewWrapper` SwiftUI view to embed `DashPlayerView`

## Testing
- `swift build` *(fails: Could not find Package.swift)*
- `xcodebuild -project mpd.xcodeproj -scheme mpd -sdk iphonesimulator build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689d8c896e84832b88c6334150112478